### PR TITLE
-4- Ported commit-msg to python 3

### DIFF
--- a/lib/commit-msg.py
+++ b/lib/commit-msg.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+import sys
+import re
+
+from enum import Enum
+
+class ExitCodes(Enum):
+    SUCCESS = 0
+    FAIL = 1
+
+class CheckCommit():
+   def check(self, commit_file):
+      print("Checking commit message in {}".format(commit_file))
+      
+      content = ""
+
+      with open(commit_file, 'r') as f:
+         content = f.read()
+         f.close()
+
+      if (self.rating_found_in(content)):
+         return ExitCodes.SUCCESS
+      else:
+         print("Commit rejected: Message [{}] does not contain a rating between 0 and 5.".format(content))
+
+         return ExitCodes.FAIL
+
+   def rating_found_in(self, content):
+      expression = re.compile("\-[0-5]\-")
+
+      result = expression.search(content)
+
+      if (result):
+         return True
+      else:
+         return False
+
+
+if __name__ == '__main__':
+   checker = CheckCommit()
+   
+   result = checker.check(sys.argv[1])
+
+   sys.exit(result.value)

--- a/lib/commit-msg.py.windows
+++ b/lib/commit-msg.py.windows
@@ -1,0 +1,45 @@
+#!%userprofile%\AppData\Local\Microsoft\WindowsApps\python.exe
+
+import sys
+import re
+
+from enum import Enum
+
+class ExitCodes(Enum):
+    SUCCESS = 0
+    FAIL = 1
+
+class CheckCommit():
+   def check(self, commit_file):
+      print("Checking commit message in {}".format(commit_file))
+      
+      content = ""
+
+      with open(commit_file, 'r') as f:
+         content = f.read()
+         f.close()
+
+      if (self.rating_found_in(content)):
+         return ExitCodes.SUCCESS
+      else:
+         print("Commit rejected: Message [{}] does not contain a rating between 0 and 5.".format(content))
+
+         return ExitCodes.FAIL
+
+   def rating_found_in(self, content):
+      expression = re.compile("\-[0-5]\-")
+
+      result = expression.search(content)
+
+      if (result):
+         return True
+      else:
+         return False
+
+
+if __name__ == '__main__':
+   checker = CheckCommit()
+   
+   result = checker.check(sys.argv[1])
+
+   sys.exit(result.value)


### PR DESCRIPTION
This pull request ports the existing functionality in Ruby to Python 3.

Note that I had to use a different command line argument index than the original Ruby script, which may mean that I'm using a newer git version than when the original script was written.  Using `git --version` for me yields `git version 2.21.0 (Apple Git-122.2)`.