### PR TITLE
Rename classes/file to better express their role

### DIFF
--- a/lib/commit-msg.rb
+++ b/lib/commit-msg.rb
@@ -4,5 +4,5 @@ require_relative 'commit_message_handler'
 file_arg = ARGV[0]
 
 if file_arg
-  CommitMessageHandler.execute(file_arg)
+  GitCommitMessageHandler.execute(file_arg)
 end

--- a/lib/commit_message_handler.rb
+++ b/lib/commit_message_handler.rb
@@ -12,19 +12,19 @@ class ExitCodes
   end
 end
 
-class CommitMessageHandler
+class GitCommitMessageHandler
 
   def self.execute(commit_message_file)
     puts "Checking Commit Message in (#{commit_message_file})"
     message = GitCommitMessageAdapter.message_from_file(commit_message_file)
 
-    CommitScoreWriter.write(message)
+    GitCommitScoreWriter.write(message)
     overwrite_commit_message_file(commit_message_file, message)
     return ExitCodes.success
   end
 
   def self.overwrite_commit_message_file(file, message)
-    message_writer = CommitMessageWriter.new(message)
+    message_writer = GitCommitMessageWriter.new(message)
     message_writer.write_to_file(file)
   end
 end

--- a/lib/commit_message_writer.rb
+++ b/lib/commit_message_writer.rb
@@ -1,4 +1,4 @@
-class CommitMessageWriter
+class GitCommitMessageWriter
   def initialize(message)
     @message = message
   end

--- a/lib/commit_score_writer.rb
+++ b/lib/commit_score_writer.rb
@@ -1,6 +1,6 @@
 require_relative 'joy_config'
 
-class CommitScoreWriter
+class GitCommitScoreWriter
   def self.write(message)
     config = JoyConfig.new
     out_file = File.new(config.score_file_name, "w")

--- a/lib/post-commit.rb
+++ b/lib/post-commit.rb
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 require_relative 'post_commit_handler'
 
-PostCommitHandler.execute
+GitPostCommitHandler.execute

--- a/lib/post_commit_handler.rb
+++ b/lib/post_commit_handler.rb
@@ -2,7 +2,7 @@ require_relative 'query_requestor_selector'
 require_relative 'query_builder_selector'
 require_relative 'git_commit_adapter'
 
-class PostCommitHandler
+class GitPostCommitHandler
 
   def self.execute
     # Requestor and Builder are from configurable factory

--- a/spec/git_commit_message_handler_spec.rb
+++ b/spec/git_commit_message_handler_spec.rb
@@ -7,7 +7,7 @@ describe 'Commit Message Handler' do
   let(:commit_file_name) {SpecUtils::Resource.file("PassingWith3.txt2")}
 
   it 'should tell me the file name' do
-    output = SpecUtils::Capture.stdout { CommitMessageHandler.execute commit_file_name }
+    output = SpecUtils::Capture.stdout { GitCommitMessageHandler.execute commit_file_name }
     expect(output).to include "(#{commit_file_name})"
   end
 
@@ -20,12 +20,12 @@ describe 'Commit Message Handler' do
     end
 
     it 'should succeed' do
-      status = CommitMessageHandler.execute commit_file_name
+      status = GitCommitMessageHandler.execute commit_file_name
       expect(status).to eq(ExitCodes.success)
     end
 
     it 'should remove the score from the commit message subject' do
-      status = CommitMessageHandler.execute commit_file_name
+      status = GitCommitMessageHandler.execute commit_file_name
       file_content = File.readlines(commit_file_name)
       expect(file_content.grep(/\-[0-5]\-/).none?).to be true
     end
@@ -34,7 +34,7 @@ describe 'Commit Message Handler' do
     context 'TJ_SCORES file does not exist' do
       it 'should create the TJ_SCORES file' do
         File.delete(@score_file_name) if File.exist?(@score_file_name)
-        status = CommitMessageHandler.execute commit_file_name
+        status = GitCommitMessageHandler.execute commit_file_name
         expect(File.exist?(@score_file_name)).to be true
       end
     end
@@ -52,14 +52,14 @@ describe 'Commit Message Handler' do
   context 'file content does NOT contain commit pattern' do
     it 'should fail' do
       commit_file_name = SpecUtils::Resource.file("FailingMissing.txt")
-      expect { CommitMessageHandler.execute commit_file_name }.to raise_error(SystemExit, /between 0 and 5/)
+      expect { GitCommitMessageHandler.execute commit_file_name }.to raise_error(SystemExit, /between 0 and 5/)
     end
   end
 
   context 'file content contains pattern with value over 5' do
     it 'should fail' do
       commit_file_name = SpecUtils::Resource.file("FailingWith6.txt")
-      expect { CommitMessageHandler.execute commit_file_name }.to raise_error(SystemExit, /between 0 and 5/)
+      expect { GitCommitMessageHandler.execute commit_file_name }.to raise_error(SystemExit, /between 0 and 5/)
     end
   end
 

--- a/spec/git_commit_message_writer_spec.rb
+++ b/spec/git_commit_message_writer_spec.rb
@@ -9,12 +9,12 @@ BODY = "This is the body line one.\nThis is the body line two."
 describe 'Commit Message Writer' do
   context 'given no commit message' do
     it 'should throw an argument error' do
-      expect {CommitMessageWriter.new}.to raise_error(ArgumentError)
+      expect {GitCommitMessageWriter.new}.to raise_error(ArgumentError)
     end
   end
 
   context 'given a commit message with a subject and body' do
-    let(:writer){CommitMessageWriter.new(@message)}
+    let(:writer){GitCommitMessageWriter.new(@message)}
 
     before(:each) do
       @message = CommitMessage.new
@@ -36,7 +36,7 @@ describe 'Commit Message Writer' do
   end
 
   context 'given a commit message with only a subject' do
-    let(:writer){CommitMessageWriter.new(@message)}
+    let(:writer){GitCommitMessageWriter.new(@message)}
 
     before(:each) do
       @message = CommitMessage.new

--- a/spec/git_commit_score_writer_spec.rb
+++ b/spec/git_commit_score_writer_spec.rb
@@ -9,7 +9,7 @@ SCORE = 5
 describe 'Commit Score Writer' do
   context 'given no commit message' do
     it 'should throw an argument error' do
-      expect {CommitScoreWriter.write}.to raise_error(ArgumentError)
+      expect {GitCommitScoreWriter.write}.to raise_error(ArgumentError)
     end
   end
 
@@ -21,7 +21,7 @@ describe 'Commit Score Writer' do
     end
 
     it 'should write a subject and score' do
-      CommitScoreWriter.write(@message)
+      GitCommitScoreWriter.write(@message)
       expect(get_scores[SUBJECT]).to eq(SCORE)
     end
   end


### PR DESCRIPTION
Closes #8 
Renamed:
* CommitMessageHandler to GitCommitMessageHandler
* CommitMessageWriter to GitCommitMessageWriter
* CommitScoreWriter to GitCommitScoreWriter
* PostCommitHandler to GitPostCommitHandler